### PR TITLE
Use vim.notify instead of print

### DIFF
--- a/lua/cabinet/init.lua
+++ b/lua/cabinet/init.lua
@@ -39,7 +39,7 @@ function M.drawer_create(drawnm)
 		M.drawer_manager:create_drawer(drawnm)
 		return true
 	else
-		print("Drawer " .. drawnm .. " already exists")
+		vim.notify("Drawer " .. drawnm .. " already exists", vim.log.levels.WARN)
 		return false
 	end
 end
@@ -55,7 +55,7 @@ function M.drawer_select(drawnm)
 		M.drawer_manager:switch_drawer(handle)
 		return true
 	else
-		print("Drawer " .. drawnm .. " does not exist")
+		vim.notify("Drawer " .. drawnm .. " does not exist", vim.log.levels.ERROR)
 		return false
 	end
 end
@@ -70,7 +70,7 @@ function M.drawer_delete(drawnm)
 		M.drawer_manager:delete_drawer(handle)
 		return true
 	else
-		print("Drawer " .. drawnm .. " does not exist")
+		vim.notify("Drawer " .. drawnm .. " does not exist", vim.log.levels.ERROR)
 		return false
 	end
 end
@@ -85,7 +85,7 @@ function M.drawer_rename(old_drawnm, new_drawnm)
 		M.drawer_manager:get_drawer(old_drawnm):rename(new_drawnm)
 		return true
 	else
-		print("Drawer name already exists")
+		vim.notify("Drawer name already exists", vim.log.levels.WARN)
 		return false
 	end
 end
@@ -143,7 +143,7 @@ function M.buf_move(buffer, drawnm_from, drawnm_to)
 	local windows = vim.fn.getbufinfo(buffer)[1].windows
 	for _, win in ipairs(windows) do
 		if #drawer_from:list_buffers() == 1 then
-			print("Can't move the only buffer of the Drawer")
+			vim.notify("Can't move the only buffer of the Drawer", vim.log.levels.ERROR)
 			return false
 		else
 			vim.api.nvim_set_current_win(win)

--- a/lua/cabinet/manager.lua
+++ b/lua/cabinet/manager.lua
@@ -111,7 +111,7 @@ end
 function Manager:delete_drawer(handle)
 	local drawer = self:get_drawer(handle)
 	if #self.drawers == 1 then
-		print("Can't delete the only drawer")
+		vim.notify("Can't delete the only drawer", vim.log.levels.ERROR)
 		return
 	else
 		if self.current_handle == handle then

--- a/lua/cabinet/save.lua
+++ b/lua/cabinet/save.lua
@@ -69,7 +69,7 @@ function M.load_cmd()
 	end
 	vim.api.nvim_create_user_command("CabinetLoad", function(opts)
 		if opts.args == nil or opts.args == "" then
-			print("No backup specified")
+			vim.log.levels("No backup specified", vim.log.levels.ERROR)
 			return
 		end
 		local manager_file = vim.fn.readfile(cache .. "saved/" .. opts.args .. "/manager")

--- a/lua/cabinet/usercmd.lua
+++ b/lua/cabinet/usercmd.lua
@@ -1,5 +1,6 @@
 local U = {}
 local user_command = vim.api.nvim_create_user_command
+local utils = require("cabinet.utils")
 
 ---comment
 ---@param M table @The cabinet module
@@ -61,20 +62,25 @@ function U.setup(M)
 
 	user_command("DrawerListBuffers", function()
 		local current_drawnm = M.drawer_current()
+        local list = {}
 		for _, buffer in ipairs(M.drawer_list_buffers(current_drawnm)) do
 			local bufname = vim.api.nvim_buf_get_name(buffer)
 			local listed = " "
 			if vim.bo[buffer].buflisted == false then
 				listed = "u"
 			end
-			print(buffer .. " " .. listed .. " " .. bufname)
+            local str =  buffer .. " " .. listed .. " " .. bufname
+			table.insert(list, str)
 		end
+        vim.notify(utils.table_to_string(list), vim.log.levels.INFO)
 	end, {})
 
 	user_command("DrawerList", function()
+        local list = {}
 		for _, drawer in ipairs(M.drawer_list()) do
-			print(drawer)
+			table.insert(list, drawer)
 		end
+        vim.notify(utils.table_to_string(list), vim.log.levels.INFO)
 	end, {})
 	user_command("DrawerBufMove", function(opts)
 		local buffer = vim.api.nvim_get_current_buf()

--- a/lua/cabinet/utils.lua
+++ b/lua/cabinet/utils.lua
@@ -29,4 +29,8 @@ function M.win_set_scratch(window)
 	return temp
 end
 
+function M.table_to_string(tbl)
+    return table.concat(tbl, "\n")
+end
+
 return M


### PR DESCRIPTION
`print` in Lua only prints to the output console, which in Neovim is the command line. As well, print always prints a newline after it is done, which means that you need to combine each call into a singular print to even see multiple entries in a list

Changes:

- Use `WARN` and `ERROR` level logs for internal plugin calls
- Use `INFO` for usercmds `DrawerList` and `DrawerListBuffers`
- Without a plugin overwriting `vim.notify`, neovim will default to the command line
- Will present all items in the called lists

Issues not covered by PR:
- User changeable callback for mentioned user commands
- There is a bug in the buffer list function: `drawer_list_buffers` in `init.lua`. It will ignore the first buffer in the buffer list for the first drawer